### PR TITLE
Remove invalid nfeature arg for brisk and akaze

### DIFF
--- a/stitching/cli/stitch.py
+++ b/stitching/cli/stitch.py
@@ -52,7 +52,9 @@ parser.add_argument(
     "--nfeatures",
     action="store",
     default=500,
-    help="Type of features used for images matching. The default is 500.",
+    help="Number of features to be detected per image. "
+    "Only used for the detectors \'orb\' and \'sift'\. "
+    "The default is 500.",
     type=int,
 )
 parser.add_argument(

--- a/stitching/feature_detector.py
+++ b/stitching/feature_detector.py
@@ -16,6 +16,8 @@ class FeatureDetector:
     DEFAULT_DETECTOR = list(DETECTOR_CHOICES.keys())[0]
 
     def __init__(self, detector=DEFAULT_DETECTOR, **kwargs):
+        if detector in ("brisk", "akaze"): # brisk, akaze don't support nfeatures arg
+            kwargs = {key: value for key, value in kwargs.items() if key != 'nfeatures'}
         self.detector = FeatureDetector.DETECTOR_CHOICES[detector](**kwargs)
 
     def detect_features(self, img, *args, **kwargs):

--- a/stitching/feature_detector.py
+++ b/stitching/feature_detector.py
@@ -16,8 +16,6 @@ class FeatureDetector:
     DEFAULT_DETECTOR = list(DETECTOR_CHOICES.keys())[0]
 
     def __init__(self, detector=DEFAULT_DETECTOR, **kwargs):
-        if detector in ("brisk", "akaze"): # brisk, akaze don't support nfeatures arg
-            kwargs = {key: value for key, value in kwargs.items() if key != 'nfeatures'}
         self.detector = FeatureDetector.DETECTOR_CHOICES[detector](**kwargs)
 
     def detect_features(self, img, *args, **kwargs):

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -56,7 +56,10 @@ class Stitcher:
         self.img_handler = ImageHandler(
             args.medium_megapix, args.low_megapix, args.final_megapix
         )
-        self.detector = FeatureDetector(args.detector, nfeatures=args.nfeatures)
+        if args.detector in ('orb', 'sift'):
+            self.detector = FeatureDetector(args.detector, nfeatures=args.nfeatures)
+        else:
+            self.detector = FeatureDetector(args.detector)
         match_conf = FeatureMatcher.get_match_conf(args.match_conf, args.detector)
         self.matcher = FeatureMatcher(
             args.matcher_type,


### PR DESCRIPTION
The FeatureDetector gave an error when invoked with detector brisk or akaze and the (default) parameter of nfeatures. The PR will make the feature detector disregard nfeatures if detector is brisk or akaze.