### PR TITLE
Add confidence threshold to camera adjuster

### DIFF
--- a/stitching/camera_adjuster.py
+++ b/stitching/camera_adjuster.py
@@ -19,12 +19,15 @@ class CameraAdjuster:
     DEFAULT_REFINEMENT_MASK = "xxxxx"
 
     def __init__(
-        self, adjuster=DEFAULT_CAMERA_ADJUSTER, refinement_mask=DEFAULT_REFINEMENT_MASK
+        self,
+        adjuster=DEFAULT_CAMERA_ADJUSTER,
+        refinement_mask=DEFAULT_REFINEMENT_MASK,
+        confidence_threshold=1.0,
     ):
 
         self.adjuster = CameraAdjuster.CAMERA_ADJUSTER_CHOICES[adjuster]()
         self.set_refinement_mask(refinement_mask)
-        self.adjuster.setConfThresh(1)
+        self.adjuster.setConfThresh(confidence_threshold)
 
     def set_refinement_mask(self, refinement_mask):
         mask_matrix = np.zeros((3, 3), np.uint8)

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -71,7 +71,9 @@ class Stitcher:
             args.confidence_threshold, args.matches_graph_dot_file
         )
         self.camera_estimator = CameraEstimator(args.estimator)
-        self.camera_adjuster = CameraAdjuster(args.adjuster, args.refinement_mask)
+        self.camera_adjuster = CameraAdjuster(
+            args.adjuster, args.refinement_mask, args.confidence_threshold
+        )
         self.wave_corrector = WaveCorrector(args.wave_correct_kind)
         self.warper = Warper(args.warper_type)
         self.cropper = Cropper(args.crop)

--- a/stitching/stitcher.py
+++ b/stitching/stitcher.py
@@ -56,7 +56,7 @@ class Stitcher:
         self.img_handler = ImageHandler(
             args.medium_megapix, args.low_megapix, args.final_megapix
         )
-        if args.detector in ('orb', 'sift'):
+        if args.detector in ("orb", "sift"):
             self.detector = FeatureDetector(args.detector, nfeatures=args.nfeatures)
         else:
             self.detector = FeatureDetector(args.detector)


### PR DESCRIPTION
In some of my tests, I was getting the occasional match between two images that was just below the default confidence threshold (e.g. 0.9 or so). When setting the confidence threshold lower, I noticed this gave markedly worse results – even matches with confidence 0.98 completely failed to stitch. It was only digging into the C++ code I realised that the camera adjuster [completely skips](https://github.com/opencv/opencv/blob/4.x/modules/stitching/src/motion_estimators.cpp#L246) matches with a confidence below its own confidence threshold setting, which was always set to 1.0 in [`camera_adjuster.py`](https://github.com/lukasalexanderweber/stitching/blob/main/stitching/camera_adjuster.py#L27). This PR re-uses the same confidence threshold that is passed into the subsetter for the camera adjuster, which greatly improves the results on lower confidence matches.

(Also, as part of running the pre-commit hooks, the black formatter also updated some single quotes to double quotes in `stitcher.py`!)