### PR TITLE
set a non-null value to confidence_threshold for correct matches graph when using RangeMatcher

### DIFF
--- a/stitching/subsetter.py
+++ b/stitching/subsetter.py
@@ -40,7 +40,7 @@ class Subsetter:
 
     def get_matches_graph(self, img_names, pairwise_matches):
         return cv.detail.matchesGraphAsString(
-            img_names, pairwise_matches, self.confidence_threshold
+            img_names, pairwise_matches, self.confidence_threshold if(self.confidence_threshold != 0) else 0.00001 # there is a bug in opencv with 0 as confidence threshold
         )
 
     def get_indices_to_keep(self, features, pairwise_matches):

--- a/stitching/subsetter.py
+++ b/stitching/subsetter.py
@@ -40,7 +40,11 @@ class Subsetter:
 
     def get_matches_graph(self, img_names, pairwise_matches):
         return cv.detail.matchesGraphAsString(
-            img_names, pairwise_matches, self.confidence_threshold if(self.confidence_threshold != 0) else 0.00001 # there is a bug in opencv with 0 as confidence threshold
+            img_names,
+            pairwise_matches,
+            0.00001  # see issue #56
+            if (self.confidence_threshold == 0)
+            else self.confidence_threshold,
         )
 
     def get_indices_to_keep(self, features, pairwise_matches):

--- a/tests/test_range_width_matcher.py
+++ b/tests/test_range_width_matcher.py
@@ -4,12 +4,12 @@ import unittest
 import cv2 as cv
 import numpy as np
 
-from .context import FeatureDetector, FeatureMatcher
+from .context import FeatureDetector, FeatureMatcher, Stitcher
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
-class TestImageRegistration(unittest.TestCase):
+class TestRangeMatcher(unittest.TestCase):
     def test_BestOf2NearestRangeMatcher(self):
         img1 = cv.imread(os.path.join(TEST_DIR, "testdata", "weir_1.jpg"))
         img2 = cv.imread(os.path.join(TEST_DIR, "testdata", "weir_2.jpg"))
@@ -30,3 +30,20 @@ class TestImageRegistration(unittest.TestCase):
                 ),
             )
         )
+
+    def test_matches_graph_issue56(self):
+        settings = {
+            "range_width": 1,
+            "confidence_threshold": 0,
+            "matches_graph_dot_file": "range_width_matches_graph.txt",
+        }
+        stitcher = Stitcher(**settings)
+        stitcher.stitch(
+            [
+                os.path.join(TEST_DIR, "testdata", "weir_1.jpg"),
+                os.path.join(TEST_DIR, "testdata", "weir_2.jpg"),
+                os.path.join(TEST_DIR, "testdata", "weir_3.jpg"),
+            ]
+        )
+
+        # TODO: Automated test that matches graph is correct


### PR DESCRIPTION
set an almost null value because there is a bug when calling `opencv.matchesGraphAsString` with 0 as `confidence_threshold`